### PR TITLE
Update i2c.py comments to English

### DIFF
--- a/pironman/i2c.py
+++ b/pironman/i2c.py
@@ -7,12 +7,12 @@ class I2C():
     SLAVE  = 1
     RETRY = 5
 
-    def __init__(self, *args, **kargs):     # *args表示位置参数（形式参数），可无，； **kargs表示默认值参数，可无。
+    def __init__(self, *args, **kargs):     
         super().__init__()
         self._bus = 1
         self._smbus = SMBus(self._bus)
 
-    def _i2c_write_byte(self, addr, data):   # i2C 写系列函数
+    def _i2c_write_byte(self, addr, data):                      # i2C write function
         return self._smbus.write_byte(addr, data)
 
     def _i2c_write_byte_data(self, addr, reg, data):
@@ -24,7 +24,7 @@ class I2C():
     def _i2c_write_i2c_block_data(self, addr, reg, data):
         return self._smbus.write_i2c_block_data(addr, reg, data)
 
-    def _i2c_read_byte(self, addr):   # i2C 读系列函数
+    def _i2c_read_byte(self, addr):                             # i2C read functions
         return self._smbus.read_byte(addr)
 
     def _i2c_read_i2c_block_data(self, addr, reg, num):
@@ -37,48 +37,48 @@ class I2C():
         else:
             return False
 
-    def scan(self):                             # 查看有哪些i2c设备
+    def scan(self):                                             # scan available i2c devices
         cmd = "i2cdetect -y %s" % self._bus
-        _, output = self.run_command(cmd)          # 调用basic中的方法，在linux中运行cmd指令，并返回运行后的内容
+        _, output = self.run_command(cmd)                       # run linux command and return the output of it
 
-        outputs = output.split('\n')[1:]        # 以回车符为分隔符，分割第二行之后的所有行
+        outputs = output.split('\n')[1:]                        
         addresses = []
         for tmp_addresses in outputs:
             if tmp_addresses == "":
                 continue
             tmp_addresses = tmp_addresses.split(':')[1]
-            tmp_addresses = tmp_addresses.strip().split(' ')    # strip函数是删除字符串两端的字符，split函数是分隔符
+            tmp_addresses = tmp_addresses.strip().split(' ')    # remove leading & trailing space, then split by space 
             for address in tmp_addresses:
                 if address != '--':
                     addresses.append(int(address, 16))
         return addresses
 
-    def send(self, send, addr, timeout=0):                      # 发送数据，addr为从机地址，send为数据
+    def send(self, send, addr, timeout=0):                      # sending data. `send`: data to be sent, `addr`: receiver's address 
         if isinstance(send, bytearray):
             data_all = list(send)
         elif isinstance(send, int):
             data_all = []
             d = "{:X}".format(send)
-            d = "{}{}".format("0" if len(d)%2 == 1 else "", d)  # format是将()中的内容对应填入{}中，（）中的第一个参数是一个三目运算符，if条件成立则为“0”，不成立则为“”(空的意思)，第二个参数是d，此行代码意思为，当字符串为奇数位时，在字符串最强面添加‘0’，否则，不添加， 方便以下函数的应用
+            d = "{}{}".format("0" if len(d)%2 == 1 else "", d)  
             # print(d)
-            for i in range(len(d)-2, -1, -2):       # 从字符串最后开始取，每次取2位
-                tmp = int(d[i:i+2], 16)             # 将两位字符转化为16进制
+            for i in range(len(d)-2, -1, -2):                   # taking two chars in each iteration from right to left 
+                tmp = int(d[i:i+2], 16)                         # convert 2-digit decimal to hex
                 # print(tmp)
-                data_all.append(tmp)                # 添加到data_all数组中
+                data_all.append(tmp)                            
             data_all.reverse()
         elif isinstance(send, list):
             data_all = send
         else:
             raise ValueError("send data must be int, list, or bytearray, not {}".format(type(send)))
 
-        if len(data_all) == 1:                      # 如果data_all只有一组数
+        if len(data_all) == 1:                    
             data = data_all[0]
             self._i2c_write_byte(addr, data)
-        elif len(data_all) == 2:                    # 如果data_all只有两组数
+        elif len(data_all) == 2:                   
             reg = data_all[0]
             data = data_all[1]
             self._i2c_write_byte_data(addr, reg, data)
-        elif len(data_all) == 3:                    # 如果data_all只有三组数
+        elif len(data_all) == 3:                    
             reg = data_all[0]
             data = (data_all[2] << 8) + data_all[1]
             self._i2c_write_word_data(addr, reg, data)
@@ -87,8 +87,8 @@ class I2C():
             data = list(data_all[1:])
             self._i2c_write_i2c_block_data(addr, reg, data)
 
-    def recv(self, recv, addr=0x00, timeout=0):     # 接收数据
-        if isinstance(recv, int):                   # 将recv转化为二进制数
+    def recv(self, recv, addr=0x00, timeout=0):                 # receive data
+        if isinstance(recv, int):                               # convert `recv` to bytearray
             result = bytearray(recv)
         elif isinstance(recv, bytearray):
             result = recv
@@ -98,7 +98,7 @@ class I2C():
             result[i] = self._i2c_read_byte(addr)
         return result
 
-    def mem_write(self, data, addr, memaddr, timeout=5000, addr_size=8): #memaddr match to chn
+    def mem_write(self, data, addr, memaddr, timeout=5000, addr_size=8): # memaddr match to chn
         if isinstance(data, bytearray):
             data_all = list(data)
         elif isinstance(data, list):
@@ -117,7 +117,7 @@ class I2C():
         # print(data_all)
         self._i2c_write_i2c_block_data(addr, memaddr, data_all)
 
-    def mem_read(self, data, addr, memaddr, timeout=5000, addr_size=8):     # 读取数据
+    def mem_read(self, data, addr, memaddr, timeout=5000, addr_size=8):  # read data
         if isinstance(data, int):
             num = data
         elif isinstance(data, bytearray):


### PR DESCRIPTION
- Change `i2c.py` comments to English for universal readiness 
- Remove unnecessary comments (e.g. definitions of `*args`, `strip`, `format`, `split`, etc.)