### PR TITLE
Make fan temperature hysteresis configurable

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -24,9 +24,13 @@
 #
 # rgb_pin, rgb signal pin, could be 10(spi), 12(PWM) or 21(PCM)
 #
+# temp_lower_set, hysteresis temperature offset for fan control (default 2)
+#                 fan will turn off when temp drops below (fan_temp - temp_lower_set)
+#
 
 temp_unit = C
-fan_temp = 50
+fan_temp = 60
+temp_lower_set = 15
 screen_always_on = False
 screen_off_time = 60
 rgb_enable = True

--- a/pironman/main.py
+++ b/pironman/main.py
@@ -93,6 +93,7 @@ try:
     config.read(config_file)
     temp_unit = config['all']['temp_unit']
     fan_temp = float(config['all']['fan_temp'])
+    temp_lower_set = float(config['all'].get('temp_lower_set', 2))
     screen_always_on = config['all']['screen_always_on']
     if screen_always_on == 'True':
         screen_always_on = True
@@ -114,6 +115,7 @@ except Exception as e:
     config['all'] ={
                     'temp_unit':temp_unit,
                     'fan_temp':fan_temp,
+                    'temp_lower_set':temp_lower_set,
                     'screen_always_on':screen_always_on,
                     'screen_off_time':screen_off_time,
                     'rgb_enable':rgb_enable,


### PR DESCRIPTION
- Add temp_lower_set configuration parameter to config.txt
- Default: fan_temp = 60C, temp_lower_set = 15 (fan turns off at 45C)
- Improves thermal efficiency by preventing fan short-cycling
- Previously hardcoded to 2C hysteresis